### PR TITLE
feat: unify header — AppHeader + LanguagePicker (#19)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -8,7 +8,7 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 
 - [x] Home + learn content, solo/practice setup flow (`App.tsx`, `HomeScreen.tsx`)
 - [x] Session runner — `session.*` / `setup.*` wired in `SessionView.tsx`
-- [x] EN + RU + ES + BE — all four suite locales; 4-button language selector in header
+- [x] EN + RU + ES + BE — all four suite locales; dropdown LanguagePicker in header
 - [x] Team session entry — `home.start_team` disabled CTA on home screen with Firebase tooltip
 - [x] Card value legend on home screen — `home.cards_title` + `cards.*` descriptions
 - [x] Card value tooltips — `cards.*` wired as `title` on all card buttons in `SessionView.tsx`
@@ -28,6 +28,7 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - [ ] [#14] UX: Reveal animation and consensus celebration
 - [x] [#15] Integration: Team Identity → Planning Poker participant auto-import — implemented
 - [x] [#16] Integration: Scrum Facilitator → Planning Poker sprint planning deep-link — documented (PP side already implemented via `?stories=`; Scrum Facilitator side tracked in scrum-facilitator repo)
+- [x] [#19] UX: Header unification — AppHeader + LanguagePicker (white, sticky, h-14)
 - [ ] [#17] Feature: Session results export — share image and copy summary text
 
 ## localStorage keys
@@ -42,6 +43,11 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - **`?stories=` deep-link contract** (suite integration point): any app can open Planning Poker with pre-populated stories by appending `?stories=<URL-encoded JSON array of {title, description?}>` to the PP URL. Implemented in issue #8. Change Planner uses this today; Scrum Facilitator sprint-planning phase is the next consumer (tracked in scrum-facilitator repo).
 
 ## Agent Log
+
+### 2026-05-27 — feat: header unification — AppHeader + LanguagePicker (#19)
+- Done #19: copied `AppHeader.tsx` + `LanguagePicker.tsx` from design-system into `src/components/`; replaced dark `bg-gray-800` header block in `App.tsx` with `<AppHeader title={t('app.title')} onTitleClick={() => setPhase('home')} navItems={[learn, history(conditional)]} />`; removed inline 4-button language switcher; header is now white, sticky, h-14, consistent with suite
+- Remaining approved issues: #20 (dark mode), #17 (results export), #21 (Firebase team sessions), #13 (session history), #14 (reveal animation), #5 (voting timer), #7 (keyboard accessibility)
+- Next task: check issues for human feedback; implement next approved item
 
 ### 2026-05-23 — feat: planning-poker:lastSession localStorage key (#12) + ?stories= contract docs (#16)
 - Done #12: `handleSessionBack` in App.tsx now writes `planning-poker:lastSession` JSON (`sessionName`, `deckType`, `storyCount`, `estimatedCount`, `avgPoints`, `date`) after each completed session; `avgPoints` is null for non-numeric decks (T-shirt sizing)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { CardValue, DeckType, GamePhase, Story, PokerSession } from './types'
 import { DECKS } from './types'
 import SessionView from './components/SessionView'
+import AppHeader from './components/AppHeader'
 
 interface DeeplinkStory {
   title: string
@@ -50,7 +51,7 @@ function pokerSessionToStories(p: PokerSession): Story[] {
 }
 
 export default function App() {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const [deeplinkedStories, setDeeplinkedStories] = useState<DeeplinkStory[]>(parseDeeplinkStories)
   const [phase, setPhase] = useState<GamePhase>(() =>
     parseDeeplinkStories().length > 0 ? 'setup' : 'home'
@@ -159,72 +160,18 @@ export default function App() {
     { value: 'powers2',   labelKey: 'setup.deck_powers2' },
   ]
 
-  const navItems: { key: GamePhase; label: string }[] = [{ key: 'learn', label: t('learn.title') }]
-
   return (
     <div className="min-h-screen flex flex-col bg-gray-900">
-      <header className="bg-gray-800 border-b border-gray-700 sticky top-0 z-10">
-        <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <a
-              href="https://agile-toolkit.github.io/"
-              title="Agile Toolkit"
-              className="text-gray-400 hover:text-gray-200 transition-colors flex-shrink-0"
-            >
-              <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                <rect x="1" y="1" width="6" height="6" rx="1"/>
-                <rect x="9" y="1" width="6" height="6" rx="1"/>
-                <rect x="1" y="9" width="6" height="6" rx="1"/>
-                <rect x="9" y="9" width="6" height="6" rx="1"/>
-              </svg>
-            </a>
-            <button
-              type="button"
-              onClick={() => setPhase('home')}
-              className="font-semibold text-brand-400 hover:text-brand-300"
-            >
-              {t('app.title')}
-            </button>
-          </div>
-          <div className="flex items-center gap-1">
-            {navItems.map(item => (
-              <button
-                key={item.key}
-                type="button"
-                onClick={() => setPhase(item.key)}
-                className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors ${
-                  phase === item.key
-                    ? 'bg-brand-900 text-brand-300'
-                    : 'text-gray-400 hover:bg-gray-700 hover:text-white'
-                }`}
-              >
-                {item.label}
-              </button>
-            ))}
-            {stories.length > 0 && (
-              <button type="button" onClick={() => setPhase('history')} className="btn-ghost">
-                {t('history.title')}
-              </button>
-            )}
-            <div className="ml-2 flex items-center gap-0.5">
-              {(['en', 'es', 'be', 'ru'] as const).map(lang => (
-                <button
-                  key={lang}
-                  type="button"
-                  onClick={() => i18n.changeLanguage(lang)}
-                  className={`text-xs px-1.5 py-1 rounded transition-colors ${
-                    i18n.language.startsWith(lang)
-                      ? 'bg-gray-600 text-white font-semibold'
-                      : 'text-gray-400 hover:text-white hover:bg-gray-700'
-                  }`}
-                >
-                  {lang.toUpperCase()}
-                </button>
-              ))}
-            </div>
-          </div>
-        </div>
-      </header>
+      <AppHeader
+        title={t('app.title')}
+        onTitleClick={() => setPhase('home')}
+        navItems={[
+          { key: 'learn', label: t('learn.title'), active: phase === 'learn', onClick: () => setPhase('learn') },
+          ...(stories.length > 0
+            ? [{ key: 'history', label: t('history.title'), active: phase === 'history', onClick: () => setPhase('history') }]
+            : []),
+        ]}
+      />
 
       <main className="flex-1 max-w-5xl mx-auto w-full px-4 py-8">
         {phase === 'home' && (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,102 @@
+import LanguagePicker from './LanguagePicker'
+
+/**
+ * Copy this file (and LanguagePicker.tsx) into src/components/ when adopting in an app.
+ * Requires: react-i18next.
+ *
+ * Usage:
+ *   <AppHeader title={t('app.title')} onTitleClick={reset}>
+ *     {/* optional extra controls placed right of LanguagePicker *\/}
+ *   </AppHeader>
+ *
+ *   <AppHeader
+ *     title={t('app.title')}
+ *     onTitleClick={() => setScreen('home')}
+ *     navItems={[
+ *       { key: 'settings', label: t('nav.settings'), active: screen === 'settings', onClick: () => setScreen('settings') },
+ *     ]}
+ *   />
+ */
+
+interface NavItem {
+  key: string
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+interface AppHeaderProps {
+  title: string
+  onTitleClick?: () => void
+  navItems?: NavItem[]
+  children?: React.ReactNode
+}
+
+const DASHBOARD_URL = 'https://agile-toolkit.github.io/'
+
+const GridIcon = () => (
+  <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <rect x="1" y="1" width="6" height="6" rx="1"/>
+    <rect x="9" y="1" width="6" height="6" rx="1"/>
+    <rect x="1" y="9" width="6" height="6" rx="1"/>
+    <rect x="9" y="9" width="6" height="6" rx="1"/>
+  </svg>
+)
+
+export default function AppHeader({ title, onTitleClick, navItems, children }: AppHeaderProps) {
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <div className="max-w-5xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
+
+        {/* Left: dashboard link + app title */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <a
+            href={DASHBOARD_URL}
+            title="Agile Toolkit — back to dashboard"
+            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+          >
+            <GridIcon />
+          </a>
+          {onTitleClick ? (
+            <button
+              type="button"
+              onClick={onTitleClick}
+              className="font-semibold text-brand-600 hover:text-brand-700 transition-colors"
+            >
+              {title}
+            </button>
+          ) : (
+            <span className="font-semibold text-brand-600">{title}</span>
+          )}
+        </div>
+
+        {/* Right: optional nav pills + language picker + children slot */}
+        <div className="flex items-center gap-1 min-w-0">
+          {navItems && navItems.length > 0 && (
+            <nav className="flex items-center gap-0.5 mr-1">
+              {navItems.map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={item.onClick}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+                    item.active
+                      ? 'bg-brand-50 text-brand-700'
+                      : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+          )}
+
+          <LanguagePicker />
+
+          {children}
+        </div>
+
+      </div>
+    </header>
+  )
+}

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Copy this file into src/components/ when adopting in an app.
+ * Requires: react-i18next, configured with en / es / be / ru locales.
+ */
+
+const LANGUAGES = [
+  { code: 'en', label: 'EN' },
+  { code: 'es', label: 'ES' },
+  { code: 'be', label: 'BE' },
+  { code: 'ru', label: 'RU' },
+] as const
+
+type LangCode = (typeof LANGUAGES)[number]['code']
+
+function currentCode(language: string): LangCode {
+  const code = language.slice(0, 2) as LangCode
+  return LANGUAGES.some(l => l.code === code) ? code : 'en'
+}
+
+export default function LanguagePicker() {
+  const { i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const active = LANGUAGES.find(l => l.code === currentCode(i18n.language))!
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { setOpen(false); return }
+    if (!open && (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown')) {
+      e.preventDefault(); setOpen(true); return
+    }
+    if (open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      e.preventDefault()
+      const idx = LANGUAGES.findIndex(l => l.code === currentCode(i18n.language))
+      const next = e.key === 'ArrowDown'
+        ? (idx + 1) % LANGUAGES.length
+        : (idx - 1 + LANGUAGES.length) % LANGUAGES.length
+      i18n.changeLanguage(LANGUAGES[next].code)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative" onKeyDown={handleKeyDown}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors select-none"
+      >
+        <span>{active.label}</span>
+        <svg className={`w-3 h-3 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M2 4l4 4 4-4" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Language"
+          className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50 min-w-[110px]"
+        >
+          {LANGUAGES.map(lang => {
+            const isCurrent = lang.code === currentCode(i18n.language)
+            return (
+              <li
+                key={lang.code}
+                role="option"
+                aria-selected={isCurrent}
+              >
+                <button
+                  type="button"
+                  onClick={() => { i18n.changeLanguage(lang.code); setOpen(false) }}
+                  className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ${
+                    isCurrent
+                      ? 'bg-brand-50 text-brand-700 font-semibold'
+                      : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <span>{lang.label}</span>
+                  {isCurrent && (
+                    <svg className="ml-auto w-3.5 h-3.5 text-brand-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M2 7l3.5 3.5L12 3" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Automated agent commit — see BRIEF.md Agent Log for details.

- Copied `AppHeader.tsx` + `LanguagePicker.tsx` from design-system into `src/components/`
- Replaced dark `bg-gray-800` header block with standard white `AppHeader` component
- Replaced inline 4-button language switcher with dropdown `LanguagePicker`
- Header is now white, sticky, h-14 — consistent with the suite
- `npm run build` passes