### PR TITLE
feat: reveal animation and consensus celebration (#14)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -25,7 +25,7 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - [x] [#8] Integration: Change Planner → Planning Poker deep-link for effort estimation — implemented
 - [x] [#12] Integration: Write planning-poker:lastSession to localStorage for Dashboard card — implemented
 - [x] [#13] Feature: Session history persistence in localStorage — implemented
-- [ ] [#14] UX: Reveal animation and consensus celebration
+- [x] [#14] UX: Reveal animation and consensus celebration — implemented
 - [x] [#15] Integration: Team Identity → Planning Poker participant auto-import — implemented
 - [x] [#16] Integration: Scrum Facilitator → Planning Poker sprint planning deep-link — documented (PP side already implemented via `?stories=`; Scrum Facilitator side tracked in scrum-facilitator repo)
 - [x] [#19] UX: Header unification — AppHeader + LanguagePicker (white, sticky, h-14)
@@ -44,6 +44,11 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - **`?stories=` deep-link contract** (suite integration point): any app can open Planning Poker with pre-populated stories by appending `?stories=<URL-encoded JSON array of {title, description?}>` to the PP URL. Implemented in issue #8. Change Planner uses this today; Scrum Facilitator sprint-planning phase is the next consumer (tracked in scrum-facilitator repo).
 
 ## Agent Log
+
+### 2026-06-08 — feat: reveal animation and consensus celebration (#14)
+- Done #14: added CSS keyframes `pp-vote-ring` (box-shadow ring on selected card), `pp-reveal-flip` (3D perspective flip on vote badges), `pp-consensus-glow` (green glow pulse) to `index.css` — all wrapped in `@media (prefers-reduced-motion: no-preference)`; in `SessionView.tsx` added `recentVotes: Set<string>` state (tracks participants who just voted, cleared after 500ms) and `revealAnimating: boolean` state (set true on reveal, cleared after 1.5s); `castVote` adds participant to `recentVotes` → selected card gets `pp-vote-ring` class; `reveal` sets `revealAnimating = true` → left-panel vote badges get `pp-reveal-flip` with 50ms-per-participant staggered delay; `resetVotes` clears `revealAnimating`; consensus stat block gets `pp-consensus-glow` when `consensus === true` and revealed
+- Remaining approved issues: #21 (Firebase team sessions), #5 (voting timer), #7 (keyboard accessibility)
+- Next task: check issues for human feedback; implement next approved item among #5 (voting timer), #7 (keyboard accessibility)
 
 ### 2026-06-05 — feat: session history persistence (#13)
 - Done #13: added `SessionHistoryEntry` + `SessionHistoryStory` types to `types.ts`; in `App.tsx` added `loadHistory()` reading `planning-poker:history` localStorage, `sessionHistory` state initialized from localStorage, `expandedSession` state; in `handleSessionBack` now builds a `SessionHistoryEntry` and prepends to history (capped at 10), writing to `planning-poker:history`; replaced in-memory story list with persistent session history view in `phase === 'history'` — shows session cards (name, date, deck, estimated/total, avg pts) expandable to show story-level estimates + votes; added `history.no_history`, `history.clear`, `history.story_count`, `history.avg` i18n keys to EN/ES/BE/RU; removed unused `stories` state and `pokerSessionToStories` function

--- a/src/components/SessionView.tsx
+++ b/src/components/SessionView.tsx
@@ -37,6 +37,8 @@ export default function SessionView({ session, onChange, onBack }: Props) {
   const [addingParticipant, setAddingParticipant] = useState(false)
   const [addingStory, setAddingStory] = useState(false)
   const [copied, setCopied] = useState(false)
+  const [recentVotes, setRecentVotes] = useState<Set<string>>(new Set())
+  const [revealAnimating, setRevealAnimating] = useState(false)
   const resultsCardRef = useRef<HTMLDivElement>(null)
 
   const currentStory = session.stories.find(s => s.id === session.currentStoryId) ?? null
@@ -98,10 +100,20 @@ export default function SessionView({ session, onChange, onBack }: Props) {
       p.id === participantId ? { ...p, vote: value } : p
     )
     update({ stories: updatedStories, participants: updatedParticipants })
+    setRecentVotes(prev => new Set([...prev, participantId]))
+    setTimeout(() => {
+      setRecentVotes(prev => {
+        const next = new Set(prev)
+        next.delete(participantId)
+        return next
+      })
+    }, 500)
   }
 
   function reveal() {
+    setRevealAnimating(true)
     update({ revealed: true })
+    setTimeout(() => setRevealAnimating(false), 1500)
   }
 
   function resetVotes() {
@@ -111,6 +123,7 @@ export default function SessionView({ session, onChange, onBack }: Props) {
     )
     const updatedParticipants = session.participants.map(p => ({ ...p, vote: null }))
     update({ stories: updatedStories, participants: updatedParticipants, revealed: false })
+    setRevealAnimating(false)
   }
 
   function setFinalEstimate(value: CardValue) {
@@ -206,17 +219,22 @@ export default function SessionView({ session, onChange, onBack }: Props) {
               <p className="text-xs text-gray-500">{t('session.noParticipants')}</p>
             ) : (
               <ul className="space-y-1">
-                {session.participants.map(p => (
+                {session.participants.map((p, pIdx) => (
                   <li key={p.id} className="flex items-center justify-between text-sm">
                     <span className="text-gray-800 dark:text-gray-200">{p.name}</span>
                     <div className="flex items-center gap-2">
                       {currentStory && (
                         <span
-                          className={`text-xs px-1.5 py-0.5 rounded ${
+                          className={`text-xs px-1.5 py-0.5 rounded inline-block ${
                             currentStory.votes[p.id]
                               ? 'bg-green-100 dark:bg-green-900/50 text-green-700 dark:text-green-300'
                               : 'bg-gray-100 dark:bg-gray-700 text-gray-500'
-                          }`}
+                          } ${session.revealed && revealAnimating && currentStory.votes[p.id] ? 'pp-reveal-flip' : ''}`}
+                          style={
+                            session.revealed && revealAnimating && currentStory.votes[p.id]
+                              ? { animationDelay: `${pIdx * 50}ms` }
+                              : undefined
+                          }
                         >
                           {currentStory.votes[p.id]
                             ? session.revealed
@@ -320,24 +338,28 @@ export default function SessionView({ session, onChange, onBack }: Props) {
                     )}
                   </div>
                   <div className="flex flex-wrap gap-1.5">
-                    {deckValues.map(v => (
-                      <button
-                        key={v}
-                        type="button"
-                        onClick={() => castVote(participant.id, v)}
-                        disabled={session.revealed}
-                        title={cardTitle(v)}
-                        className={`w-10 h-14 border-2 rounded-lg font-bold text-sm transition-all ${
-                          currentStory.votes[participant.id] === v
-                            ? 'border-brand-400 bg-brand-50 dark:bg-brand-900/40 text-brand-700 dark:text-brand-200 scale-105 shadow'
-                            : session.revealed
-                              ? 'border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-default'
-                              : 'border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:border-brand-300 dark:hover:border-brand-500 hover:bg-gray-50 dark:hover:bg-gray-700/50'
-                        }`}
-                      >
-                        {v}
-                      </button>
-                    ))}
+                    {deckValues.map(v => {
+                      const isSelected = currentStory.votes[participant.id] === v
+                      const justVoted = isSelected && !session.revealed && recentVotes.has(participant.id)
+                      return (
+                        <button
+                          key={v}
+                          type="button"
+                          onClick={() => castVote(participant.id, v)}
+                          disabled={session.revealed}
+                          title={cardTitle(v)}
+                          className={`w-10 h-14 border-2 rounded-lg font-bold text-sm transition-all ${
+                            isSelected
+                              ? `border-brand-400 bg-brand-50 dark:bg-brand-900/40 text-brand-700 dark:text-brand-200 scale-105 shadow${justVoted ? ' pp-vote-ring' : ''}`
+                              : session.revealed
+                                ? 'border-gray-200 dark:border-gray-600 text-gray-400 dark:text-gray-500 cursor-default'
+                                : 'border-gray-200 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:border-brand-300 dark:hover:border-brand-500 hover:bg-gray-50 dark:hover:bg-gray-700/50'
+                          }`}
+                        >
+                          {v}
+                        </button>
+                      )
+                    })}
                   </div>
                 </div>
               ))}
@@ -374,7 +396,7 @@ export default function SessionView({ session, onChange, onBack }: Props) {
                       <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{t('session.median')}</div>
                       <div className="font-bold text-gray-900 dark:text-white">{med !== null ? String(med) : '—'}</div>
                     </div>
-                    <div className="bg-gray-100 dark:bg-gray-700/50 rounded-lg p-3 text-center">
+                    <div className={`bg-gray-100 dark:bg-gray-700/50 rounded-lg p-3 text-center${consensus ? ' pp-consensus-glow' : ''}`}>
                       <div className="text-xs text-gray-500 dark:text-gray-400 mb-1">{t('session.consensus')}</div>
                       <div className={`font-bold ${consensus ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}`}>
                         {consensus ? t('session.yes') : t('session.no')}

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,23 @@
 @tailwind components;
 @tailwind utilities;
 @layer base { body { @apply bg-gray-50 dark:bg-gray-950 text-gray-900 dark:text-gray-50 antialiased; } }
+@keyframes pp-vote-ring {
+  from { box-shadow: 0 0 0 0 rgba(99, 102, 241, 0.55); }
+  to   { box-shadow: 0 0 0 7px rgba(99, 102, 241, 0); }
+}
+@keyframes pp-reveal-flip {
+  from { opacity: 0; transform: perspective(300px) rotateY(-80deg); }
+  to   { opacity: 1; transform: perspective(300px) rotateY(0deg); }
+}
+@keyframes pp-consensus-glow {
+  0%, 100% { box-shadow: 0 0 0 0 rgba(34, 197, 94, 0.45); }
+  50%       { box-shadow: 0 0 0 8px rgba(34, 197, 94, 0); }
+}
+@media (prefers-reduced-motion: no-preference) {
+  .pp-vote-ring { animation: pp-vote-ring 450ms ease-out; }
+  .pp-reveal-flip { animation: pp-reveal-flip 280ms ease-out forwards; }
+  .pp-consensus-glow { animation: pp-consensus-glow 900ms ease-in-out 3; }
+}
 @layer components {
   .card { @apply bg-white dark:bg-gray-900 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-700 p-5; }
   .card-white { @apply bg-white rounded-2xl shadow-sm border border-gray-100 dark:border-gray-800 p-5; }


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Implements issue #14: CSS-only animations for vote reveal, consensus celebration, and vote cast feedback.

- **Reveal flip**: 280ms 3D perspective flip on left-panel vote badges, staggered 50ms per participant
- **Vote ring**: 450ms box-shadow pulse ring on selected card when a vote is cast
- **Consensus glow**: 900ms green glow pulse (×3) on consensus stat block when all votes agree
- All animations wrapped in `@media (prefers-reduced-motion: no-preference)` (WCAG 2.3.3)