### PR TITLE
feat: observer/spectator mode in team sessions (#32)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -11,6 +11,7 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - [x] EN + RU + ES + BE — all four suite locales; dropdown LanguagePicker in header
 - [x] Team session entry — `home.start_team` enabled when Firebase configured; disabled stub with tooltip when not
 - [x] Firebase real-time team sessions — `src/firebase.ts` (isFirebaseConfigured + getFirebaseDb); `src/components/TeamSession.tsx` (host creates 4-digit PIN, participants join by PIN, lobby shows PIN + joiners, story-by-story voting with hidden votes until host reveals, host sets final estimate per story, end writes to sprintMetrics_planningPoker + planning-poker:lastSession + session history); `team.*` i18n keys in EN/ES/BE/RU; solo mode unaffected when Firebase not configured
+- [x] Observer/spectator mode in team sessions — join checkbox on entry screen; `isObserver: true` in Firebase participant record; eye badge in lobby list; observers see vote progress but not card deck; excluded from vote denominator; `team.join_as_observer`, `team.observer_badge`, `team.voters_only` i18n keys in EN/ES/BE/RU
 - [x] Card value legend on home screen — `home.cards_title` + `cards.*` descriptions
 - [x] Card value tooltips — `cards.*` wired as `title` on all card buttons in `SessionView.tsx`
 - [x] Language toggle — uses `app.switch_lang` i18n key (removes raw EN/RU strings)
@@ -18,7 +19,7 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 
 ## Backlog
 
-- [ ] [#32] Feature: Observer/spectator mode in team sessions — join as observer (no vote card, excluded from consensus denominator); `team.join_as_observer` i18n key; host-only visibility badge
+- [x] [#32] Feature: Observer/spectator mode in team sessions — join as observer (no vote card, excluded from consensus denominator); `team.join_as_observer` i18n key; host-only visibility badge
 - [ ] [#33] UX: Story drag-to-reorder during estimation session — native HTML5 drag events, no new dependency; grip handle on story rows; solo always, team host-only; storyOrder array in Firebase for team mode
 - [ ] [#34] Integration: Sprint Metrics velocity hint in session header — read `sprint-metrics:sprints`, show trailing 3-sprint avg velocity chip in SessionView header; dismissible; only when >=3 sprints exist; `session.velocity_hint` i18n key
 - [ ] [#35] Feature: Anonymous/blind voting mode — hide participant names during voting phase to prevent anchoring bias; `blindMode: boolean` in Firebase session doc; `team.blind_mode_label/hint/anonymous_voter` i18n keys; host always sees real names; ~30 LOC in TeamSession.tsx
@@ -55,6 +56,11 @@ Planning Poker for Scrum teams: practice setup, multi-participant session, revea
 - **`?stories=` deep-link contract** (suite integration point): any app can open Planning Poker with pre-populated stories by appending `?stories=<URL-encoded JSON array of {title, description?}>` to the PP URL. Implemented in issue #8. Change Planner uses this today; Scrum Facilitator sprint-planning phase is the next consumer (tracked in scrum-facilitator repo).
 
 ## Agent Log
+
+### 2026-06-30 — feat: observer/spectator mode in team sessions (#32)
+- Done: added `isObserver?: boolean` to `FirebaseParticipant` interface; `joinAsObserver` state + checkbox on join entry screen; `handleJoin` writes `isObserver: true` to Firebase when checked; `voterEntries`/`voterCount` exclude observers from vote denominator; host lobby shows 👁 badge for observers; host voting list shows "Observer" label (no vote status) for observer entries; observer participant sees watch screen (story title + 👁 badge + vote progress) instead of card deck; `team.join_as_observer`, `team.observer_badge`, `team.voters_only` i18n keys added to EN/ES/BE/RU; auto-approved #32, #33, #34 (all past 7-day threshold)
+- Remaining: #33 (drag-to-reorder, approved), #34 (velocity hint, approved)
+- Next task: implement #33 (story drag-to-reorder — HTML5 drag events; grip handle on story rows in SessionView.tsx; solo always, team host-only; `storyOrder: string[]` in Firebase for team mode)
 
 ### 2026-06-28 — research: QR code PIN sharing, mobile swipe-to-vote, estimation accuracy
 - Done: created #38 (QR code PIN sharing in lobby — qrcode.react, ?joinPin= param), #39 (swipe-to-select card on mobile — Pointer Events API, no dependency), #40 (estimation accuracy cross-reference with Sprint Metrics — history Accuracy tab, read-only); all set to Backlog pending needs-review; project board Backlog status not set (GraphQL proxying disabled this session)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "planning-poker",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/components/TeamSession.tsx
+++ b/src/components/TeamSession.tsx
@@ -8,6 +8,7 @@ import { DECKS } from '../types'
 interface FirebaseParticipant {
   name: string
   isHost: boolean
+  isObserver?: boolean
 }
 
 interface FirebaseStory {
@@ -49,6 +50,7 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
   const [mode, setMode] = useState<'entry' | 'host' | 'participant'>('entry')
   const [name, setName] = useState('')
   const [joinPin, setJoinPin] = useState('')
+  const [joinAsObserver, setJoinAsObserver] = useState(false)
   const [pin, setPin] = useState('')
   const [participantId, setParticipantId] = useState('')
   const [selectedDeck, setSelectedDeck] = useState<DeckType>('fibonacci')
@@ -108,6 +110,7 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
     await update(ref(db, `sessions/${joinPin}/participants/${pId}`), {
       name: name.trim(),
       isHost: false,
+      ...(joinAsObserver ? { isObserver: true } : {}),
     })
     setPin(joinPin)
     setParticipantId(pId)
@@ -235,6 +238,15 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
               <p className="text-xs text-red-600 dark:text-red-400 mt-1">{joinError}</p>
             )}
           </div>
+          <label className="flex items-center gap-2 text-sm text-gray-600 dark:text-gray-400 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={joinAsObserver}
+              onChange={e => setJoinAsObserver(e.target.checked)}
+              className="rounded border-gray-300 dark:border-gray-600 text-brand-600 focus:ring-brand-500"
+            />
+            {t('team.join_as_observer')}
+          </label>
           <button
             type="button"
             onClick={handleJoin}
@@ -283,9 +295,11 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
   const deck = DECKS[session.deck ?? 'fibonacci']
   const participantEntries = Object.entries(participants)
   const nonHostEntries = participantEntries.filter(([, p]) => !p.isHost)
+  const voterEntries = participantEntries.filter(([, p]) => !p.isHost && !p.isObserver)
   const votes = currentStoryData?.votes ?? {}
-  const voteCount = Object.keys(votes).length
+  const voteCount = Object.keys(votes).filter(id => !participants[id]?.isObserver).length
   const nonHostCount = nonHostEntries.length
+  const voterCount = voterEntries.length
 
   // ── HOST VIEW ──────────────────────────────────────────────────────────
   if (mode === 'host') {
@@ -316,6 +330,11 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
                     {p.name}
                     {p.isHost && (
                       <span className="text-xs text-gray-400 dark:text-gray-600">(host)</span>
+                    )}
+                    {p.isObserver && !p.isHost && (
+                      <span className="text-xs text-gray-400 dark:text-gray-600 flex items-center gap-0.5">
+                        👁 {t('team.observer_badge')}
+                      </span>
                     )}
                   </li>
                 ))}
@@ -365,23 +384,35 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
           <div className="card space-y-3">
             <div className="flex items-center justify-between">
               <p className="text-sm text-gray-600 dark:text-gray-400">
-                {t('team.vote_progress', { done: voteCount, total: nonHostCount || participantEntries.length })}
+                {t('team.vote_progress', { done: voteCount, total: voterCount || participantEntries.length })}
+                {voterCount < nonHostCount && (
+                  <span className="ml-1 text-xs text-gray-400 dark:text-gray-600">({t('team.voters_only')})</span>
+                )}
               </p>
               <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                voteCount > 0 && voteCount >= (nonHostCount || participantEntries.length)
+                voteCount > 0 && voteCount >= (voterCount || participantEntries.length)
                   ? 'bg-green-100 text-green-700 dark:bg-green-900/30 dark:text-green-400'
                   : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
               }`}>
-                {voteCount > 0 && voteCount >= (nonHostCount || participantEntries.length) ? '✓ All voted' : t('team.waiting_for_votes')}
+                {voteCount > 0 && voteCount >= (voterCount || participantEntries.length) ? '✓ All voted' : t('team.waiting_for_votes')}
               </span>
             </div>
             <ul className="space-y-1">
               {participantEntries.map(([id, p]) => (
                 <li key={id} className="flex items-center justify-between text-sm text-gray-700 dark:text-gray-300">
-                  <span>{p.name}</span>
-                  <span className={`text-xs ${votes[id] ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-600'}`}>
-                    {votes[id] ? t('team.voted_badge') : '…'}
+                  <span className="flex items-center gap-1.5">
+                    {p.name}
+                    {p.isObserver && !p.isHost && (
+                      <span className="text-xs text-gray-400 dark:text-gray-600">👁</span>
+                    )}
                   </span>
+                  {p.isObserver ? (
+                    <span className="text-xs text-gray-400 dark:text-gray-600">{t('team.observer_badge')}</span>
+                  ) : (
+                    <span className={`text-xs ${votes[id] ? 'text-green-600 dark:text-green-400' : 'text-gray-400 dark:text-gray-600'}`}>
+                      {votes[id] ? t('team.voted_badge') : '…'}
+                    </span>
+                  )}
                 </li>
               ))}
             </ul>
@@ -484,6 +515,29 @@ export default function TeamSession({ onBack, onSessionEnd }: Props) {
     }
 
     if (session.phase === 'voting') {
+      if (participants[participantId]?.isObserver) {
+        return (
+          <div className="max-w-sm mx-auto pt-8 space-y-6">
+            <div className="card">
+              <p className="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider mb-1">
+                {t('team.story_label')}
+              </p>
+              <p className="text-lg font-semibold text-gray-900 dark:text-white">
+                {currentStoryData?.title ?? '—'}
+              </p>
+            </div>
+            <div className="card text-center space-y-2 py-6">
+              <p className="text-3xl">👁</p>
+              <p className="text-sm font-medium text-gray-600 dark:text-gray-400">{t('team.observer_badge')}</p>
+              <p className="text-xs text-gray-400 dark:text-gray-600">
+                {t('team.vote_progress', { done: voteCount, total: voterCount || participantEntries.length })}
+              </p>
+              <p className="text-xs text-gray-400 dark:text-gray-600">{t('team.waiting_for_votes')}</p>
+            </div>
+          </div>
+        )
+      }
+
       return (
         <div className="max-w-sm mx-auto pt-8 space-y-6">
           <div className="card">

--- a/src/i18n/be.json
+++ b/src/i18n/be.json
@@ -113,7 +113,10 @@
     "story_label": "Гісторыя для ацэнкі",
     "story_placeholder": "Што ацэньваем?",
     "vote_progress": "{{done}} / {{total}} прагаласавалі",
-    "voted_badge": "Галас пададзены ✓"
+    "voted_badge": "Галас пададзены ✓",
+    "join_as_observer": "Далучыцца як назіральнік",
+    "observer_badge": "Назіральнік",
+    "voters_only": "толькі галасуючыя"
   },
   "cards": {
     "half": "½ — трывіяльна, хвіліны",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -113,7 +113,10 @@
     "story_label": "Story to estimate",
     "story_placeholder": "What are we estimating?",
     "vote_progress": "{{done}} / {{total}} voted",
-    "voted_badge": "Voted ✓"
+    "voted_badge": "Voted ✓",
+    "join_as_observer": "Join as observer",
+    "observer_badge": "Observer",
+    "voters_only": "voters only"
   },
   "cards": {
     "half": "½ — trivial, minutes",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -113,7 +113,10 @@
     "story_label": "Historia a estimar",
     "story_placeholder": "¿Qué estamos estimando?",
     "vote_progress": "{{done}} / {{total}} votaron",
-    "voted_badge": "Votado ✓"
+    "voted_badge": "Votado ✓",
+    "join_as_observer": "Unirse como observador",
+    "observer_badge": "Observador",
+    "voters_only": "solo votantes"
   },
   "cards": {
     "half": "½ — trivial, minutos",

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -113,7 +113,10 @@
     "story_label": "История для оценки",
     "story_placeholder": "Что оцениваем?",
     "vote_progress": "{{done}} / {{total}} проголосовали",
-    "voted_badge": "Голос подан ✓"
+    "voted_badge": "Голос подан ✓",
+    "join_as_observer": "Присоединиться как наблюдатель",
+    "observer_badge": "Наблюдатель",
+    "voters_only": "только голосующие"
   },
   "cards": {
     "half": "½ — тривиально, минуты",


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Implements #32: observer/spectator mode for Firebase team sessions.

**What changed:**
- `FirebaseParticipant` gains `isObserver?: boolean` field
- Join entry screen has a new "Join as observer" checkbox (default off)
- `handleJoin` writes `isObserver: true` to Firebase when checked
- Vote denominator now uses `voterEntries` (excludes observers), so host can reveal when all non-observer participants have voted
- Host lobby: observers shown with 👁 badge
- Host voting list: observers shown with "Observer" label instead of voted/waiting status
- Observer participant view: sees story title + vote progress but no card deck
- `team.join_as_observer`, `team.observer_badge`, `team.voters_only` i18n keys added to EN/ES/BE/RU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CzsrkXkryLDkRiHoewsRfu)_